### PR TITLE
Services made public

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,11 +8,14 @@ services:
     cron.resolver:
         class: "%cron.resolver.class%"
         arguments: ["@cron.manager", "@cron.command_builder", "%kernel.root_dir%"]
+        public: true
     cron.manager:
         class: "%cron.manager.class%"
         arguments: ["@doctrine"]
+        public: true
     cron.executor:
         class: "%cron.executor.class%"
+        public: true
     cron.command_builder:
         class: "%cron.command_builder.class%"
         arguments: ["%kernel.environment%"]


### PR DESCRIPTION
Since version 3.2 Symfony throws a warning if service is fetched through container but is not made public and from version 4 will throw an error. So in order to fix it, I've made services public. It would be better if these services are injected but this will work too for now.

This is the error Symfony throws before the change

`User Deprecated: The "cron.resolver" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead. {"exception":"[object] (ErrorException(code: 0): User Deprecated: The \"cron.resolver\" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead`